### PR TITLE
chore: Git管理対象外のキャッシュ設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,6 @@ __pycache__/
 
 # Node.js
 node_modules/
-
+.eslintcache
+*.tsbuildinfo
+.npm/


### PR DESCRIPTION
`.gitignore` に Node/TypeScript のキャッシュ関連を追加しました。

- `.eslintcache`
- `*.tsbuildinfo`
- `.npm/`

Refs #1