### PR TITLE
docs: IssueテンプレートにDoDと運用チェックを追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/learning-task.yml
+++ b/.github/ISSUE_TEMPLATE/learning-task.yml
@@ -55,3 +55,24 @@ body:
         - label: 可読性を改善して動作確認した（第2段階）
         - label: 10分以内・ノーエラーで実装できた
         - label: 上記を3回連続で達成した
+
+  - type: checkboxes
+    id: pr_review_close_checklist
+    attributes:
+      label: PR / Review / Close Checklist (DoD)
+      description: PR作成以降の運用チェックです。Issue クローズ前に完了してください。
+      options:
+        - label: ブランチ `solve/{problem-slug}` を作成して着手した（`status/in-progress`）
+        - label: "PR を作成し、本文に `Refs #<issue-number>` を記載した（`status/in-review`）"
+        - label: レビュー指摘対応中は `status/review-fix` へ更新し、再レビュー依頼時に `status/in-review` へ戻した
+        - label: PR を `Squash and merge` で `main` にマージした
+        - label: 検証結果と必要なメモを Issue コメントに記録した
+        - label: `status/done` に更新後、`status/closed` に更新して Issue をクローズした
+
+  - type: markdown
+    attributes:
+      value: |
+        ### Done Definition（クローズ条件）
+        - `main` へマージ済み
+        - 検証結果と必要メモを Issue コメントに記録済み
+        - PR のチェックリスト完了済み

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,10 @@
 - すべてのコミットメッセージに `Refs #<issue-number>` を含める
 - PR本文に `Refs #<issue-number>` を含める
 - Issue はラベル（`status/*`, `priority/*`, `type/*`）で管理し、`status/*` は常に1つだけ付ける
+- 学習課題 Issue は `.github/ISSUE_TEMPLATE/learning-task.yml` 準拠の本文で作成・更新する
 - 問題ディレクトリは `solutions/leetcode/{problem-slug}/` を必須とする
 - 実装言語は TypeScript に統一する
+- Issue クローズは DoD を満たした場合のみ行う（`main` マージ済み、検証結果と必要メモ記録済み、`status/done` 更新済み）
 
 ## Command Permission Policy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,13 @@
 - 問題の解答に関する質問を AI へ依頼しない
 - Issue / PR / コミットの関連付けを必ず行う
 - Issue / PR / コミットメッセージ（必要なコメント含む）は日本語で記述する
+- 学習課題 Issue は `.github/ISSUE_TEMPLATE/learning-task.yml` 準拠で作成・更新する
+
+## Issue DoD / Close Rule
+
+- Issue の Learning Progress Checklist と PR/Review/Close のチェック項目を更新しながら進める
+- `status/done` は次を満たしたときにのみ付与する:
+  - 対象PRが `main` にマージ済み
+  - 検証結果と必要なメモを Issue コメントに記録済み
+  - PR チェックリストが完了
+- Issue は `status/done` を確認してから `status/closed` に更新してクローズする


### PR DESCRIPTION
Issue運用の再発防止として、テンプレートと運用ルールを更新しました。

- 学習課題 Issue をテンプレート準拠で作成・更新するルールを追加
- Issue クローズの DoD を明記
- Issue テンプレートに PR/レビュー/クローズのチェックを追加

Refs #1