### PR TITLE
feat: linked-list-cycle を追加

### DIFF
--- a/solutions/leetcode/linked-list-cycle/README.md
+++ b/solutions/leetcode/linked-list-cycle/README.md
@@ -1,0 +1,25 @@
+# linked-list-cycle
+
+## 問題
+
+- URL: https://leetcode.com/problems/linked-list-cycle/
+
+## 実行方法
+
+```bash
+# 例: プロジェクト標準の TypeScript 実行コマンドを記載
+# npm run test
+# node --import tsx --test solutions/leetcode/linked-list-cycle/solution.test.ts
+# npm run lint -- solutions/leetcode/linked-list-cycle/solution.test.ts
+```
+
+## メモ
+
+- 必要なメモを記録
+
+## 最終判断（リポジトリに残す）
+
+- 採用した方針: Floyd の2ポインタ法（`slow` は1ステップ、`fast` は2ステップ）で、同一ノード参照への到達有無でサイクルを判定する。
+- 計算量（時間/空間）: 時間 `O(n)`、追加メモリ `O(1)`。
+- 代替案と不採用理由: 訪問済みノード参照を `Set` で保持する案は実装は直感的だが、追加メモリが `O(n)` となり問題の定数メモリ条件に合わないため不採用。ノード書き換え案は入力破壊を伴うため不採用。
+- レビューでの合意事項: 実務では静的解析前提のため、実行時に起きにくいケースでも `null` チェックを明示し、型安全性を優先する。

--- a/solutions/leetcode/linked-list-cycle/solution-1st.ts
+++ b/solutions/leetcode/linked-list-cycle/solution-1st.ts
@@ -22,8 +22,8 @@ export function hasCycle(head: ListNode | null): boolean {
   let slow: ListNode | null = head;
   let fast: ListNode | null = head;
 
-  while ( fast !== null && fast.next !== null) {
-    slow =  slow !== null ? slow.next : null;
+  while (fast !== null && fast.next !== null) {
+    slow = slow !== null ? slow.next : null;
     fast = fast.next.next
     if (slow === fast) {
       return true;

--- a/solutions/leetcode/linked-list-cycle/solution-1st.ts
+++ b/solutions/leetcode/linked-list-cycle/solution-1st.ts
@@ -1,0 +1,33 @@
+/**
+ * Definition for singly-linked list.
+ * class ListNode {
+ *     val: number
+ *     next: ListNode | null
+ *     constructor(val?: number, next?: ListNode | null) {
+ *         this.val = (val===undefined ? 0 : val)
+ *         this.next = (next===undefined ? null : next)
+ *     }
+ * }
+ */
+export class ListNode {
+  val: number
+  next: ListNode | null
+  constructor(val?: number, next?: ListNode | null) {
+    this.val = (val===undefined ? 0 : val)
+    this.next = (next===undefined ? null : next)
+  }
+}
+
+export function hasCycle(head: ListNode | null): boolean {
+  let slow: ListNode | null = head;
+  let fast: ListNode | null = head;
+
+  while ( fast !== null && fast.next !== null) {
+    slow =  slow !== null ? slow.next : null;
+    fast = fast.next.next
+    if (slow === fast) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/solutions/leetcode/linked-list-cycle/solution-2nd.ts
+++ b/solutions/leetcode/linked-list-cycle/solution-2nd.ts
@@ -1,0 +1,38 @@
+/**
+ * Definition for singly-linked list.
+ * class ListNode {
+ *     val: number
+ *     next: ListNode | null
+ *     constructor(val?: number, next?: ListNode | null) {
+ *         this.val = (val===undefined ? 0 : val)
+ *         this.next = (next===undefined ? null : next)
+ *     }
+ * }
+ */
+export class ListNode {
+  val: number;
+  next: ListNode | null;
+
+  constructor(val?: number, next?: ListNode | null) {
+    this.val = val === undefined ? 0 : val;
+    this.next = next === undefined ? null : next;
+  }
+}
+
+// 連結リストにサイクルが存在するかを判定する。
+// slow/fast の2ポインタを使い、参照が一致したらサイクルありとみなす。
+export function hasCycle(head: ListNode | null): boolean {
+  let slow: ListNode | null = head;
+  let fast: ListNode | null = head;
+
+  // fast が2手進める間だけループを継続する（進めなくなったらサイクルなし）。
+  while (slow !== null && fast !== null && fast.next !== null) {
+    slow = slow.next;
+    fast = fast.next.next;
+    // 同じノード参照に到達した時点でサイクルあり。
+    if (fast !== null && fast === slow) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/solutions/leetcode/linked-list-cycle/solution-3rd.ts
+++ b/solutions/leetcode/linked-list-cycle/solution-3rd.ts
@@ -1,0 +1,40 @@
+/**
+ * Definition for singly-linked list.
+ * class ListNode {
+ *     val: number
+ *     next: ListNode | null
+ *     constructor(val?: number, next?: ListNode | null) {
+ *         this.val = (val===undefined ? 0 : val)
+ *         this.next = (next===undefined ? null : next)
+ *     }
+ * }
+ */
+export class ListNode {
+  val: number;
+  next: ListNode | null;
+
+  constructor(val?: number, next?: ListNode | null) {
+    this.val = val === undefined ? 0 : val;
+    this.next = next === undefined ? null : next;
+  }
+}
+
+// 連結リストにサイクルが存在するかを判定する。
+// slow/fast の2ポインタを使い、参照が一致したらサイクルありとみなす。
+export function hasCycle(head: ListNode | null): boolean {
+  let slow: ListNode | null = head;
+  let fast: ListNode | null = head;
+
+  // fast が2手進める間だけループを継続する（進めなくなったらサイクルなし）。
+  while ( slow !== null && fast !== null && fast.next !== null ){
+    slow = slow.next;
+    fast = fast.next.next;
+
+    // 同じノード参照に到達した時点でサイクルあり。
+    if ( slow === fast ){
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/solutions/leetcode/linked-list-cycle/solution-3rd.ts
+++ b/solutions/leetcode/linked-list-cycle/solution-3rd.ts
@@ -26,12 +26,12 @@ export function hasCycle(head: ListNode | null): boolean {
   let fast: ListNode | null = head;
 
   // fast が2手進める間だけループを継続する（進めなくなったらサイクルなし）。
-  while ( slow !== null && fast !== null && fast.next !== null ){
+  while (slow !== null && fast !== null && fast.next !== null) {
     slow = slow.next;
     fast = fast.next.next;
 
     // 同じノード参照に到達した時点でサイクルあり。
-    if ( slow === fast ){
+    if (slow === fast) {
       return true;
     }
   }

--- a/solutions/leetcode/linked-list-cycle/solution-target.ts
+++ b/solutions/leetcode/linked-list-cycle/solution-target.ts
@@ -1,0 +1,5 @@
+// テスト対象を切り替えるための集約ファイル。
+// 1stトライ: "./solution-1st"
+// 2ndトライ: "./solution-2nd"
+// 3rdトライ: "./solution-3rd"
+export { hasCycle, ListNode } from "./solution-3rd";

--- a/solutions/leetcode/linked-list-cycle/solution.test.ts
+++ b/solutions/leetcode/linked-list-cycle/solution.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { hasCycle, ListNode } from "./solution-target";
+
+function buildList(values: number[], pos: number): ListNode | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const nodes = values.map((value) => new ListNode(value));
+  for (let i = 0; i < nodes.length - 1; i += 1) {
+    nodes[i].next = nodes[i + 1];
+  }
+
+  if (pos >= 0) {
+    nodes[nodes.length - 1].next = nodes[pos];
+  }
+
+  return nodes[0];
+}
+
+describe("hasCycle", () => {
+  it("サンプル1: head=[3,2,0,-4], pos=1 は true", () => {
+    const head = buildList([3, 2, 0, -4], 1);
+    assert.equal(hasCycle(head), true);
+  });
+
+  it("サンプル2: head=[1,2], pos=0 は true", () => {
+    const head = buildList([1, 2], 0);
+    assert.equal(hasCycle(head), true);
+  });
+
+  it("サンプル3: head=[1], pos=-1 は false", () => {
+    const head = buildList([1], -1);
+    assert.equal(hasCycle(head), false);
+  });
+});


### PR DESCRIPTION
## Summary

- `linked-list-cycle` の作業ディレクトリを作成
- 1st/2nd/3rd トライを分離して保持できる構成を追加
- 3rdトライの解答をテスト対象として設定
- 問題READMEの Final Decisions を更新

## Target Problem

- LeetCode URL: https://leetcode.com/problems/linked-list-cycle/
- Problem slug: linked-list-cycle
- Related Issue (Required): #5

## Verification

- [x] ローカル実行で動作確認した
- [x] 実行コマンドを記載した

実行コマンド:

```bash
node --import tsx --test solutions/leetcode/linked-list-cycle/solution.test.ts
```

## Implementation Rationale (for review)

- 方針: Floyd の2ポインタ法
- 計算量: 時間 O(n) / 追加メモリ O(1)
- 代替案と不採用理由: 訪問済みノード保持は O(n) メモリのため不採用
- 最終決定として残す内容（solution README へ反映）: 反映済み

## Review Scope

レビュー対象ファイル:

- [x] `solutions/leetcode/linked-list-cycle/solution-3rd.ts`
- [x] `solutions/leetcode/linked-list-cycle/README.md`

レビュー対象外ファイル（確認不要・参考のみ）:

- [x] `solutions/leetcode/linked-list-cycle/solution-1st.ts`
- [x] `solutions/leetcode/linked-list-cycle/solution-2nd.ts`
- [x] `solutions/leetcode/linked-list-cycle/solution-target.ts`
- [x] `solutions/leetcode/linked-list-cycle/solution.test.ts`

Refs #5
